### PR TITLE
Added optional Rotten Tomatoes data retrieval

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -92,6 +92,7 @@ export default class Moviegrabber extends Plugin {
 			url.searchParams.append('y', year[0].replace(/[\(\)]/g, ''));
 		}
 		url.searchParams.append('type', type);
+		url.searchParams.append('tomatoes', this.settings.RottenTomatoes.toString());
 
 		console.log(`requesting: ${url}`);
 
@@ -146,6 +147,7 @@ export default class Moviegrabber extends Plugin {
 		url.searchParams.append('apikey', this.settings.OMDb_API_Key);
 		url.searchParams.append('i', movie.imdbID);
 		url.searchParams.append('plot', this.settings.PlotLength);
+		url.searchParams.append('tomatoes', this.settings.RottenTomatoes.toString());
 
 		// fetch data
 		var response;

--- a/src/MoviegrabberSearchObject.ts
+++ b/src/MoviegrabberSearchObject.ts
@@ -41,7 +41,18 @@ export interface MovieData{
     Website: string,
     totalSeasons: number,
     Response: boolean,
-    YoutubeEmbed: string
+    YoutubeEmbed: string,
+    tomatoURL: string,
+    tomatoMeter: number,
+    tomatoImage: string,
+    tomatoRating: number,
+    tomatoReviews: number,
+    tomatoFresh: number,
+    tomatoRotten: number,
+    tomatoConsensus: string,
+    tomatoUserMeter: number,
+    tomatoUserRating: number,
+    tomatoUserReviews: number
   }
 
 export interface MovieRating{
@@ -57,40 +68,55 @@ export class Rating implements MovieRating {
     }
 }
 
-interface MovieDataLowercase {
+export interface MovieDataLowercase extends LowerCase<MovieData> {
     [key:string]: string
 }
 
+// given a lowercase key, return the mixed case key
+type LowerCase<T> = {  [Property in keyof T as `${Lowercase<string & Property>}`]: Property };
+
 // this is used to make tags case insensitive
+// should ensure that lowercase version of any new property of MovieData gets created without manual effort
 export const MOVIE_DATA_LOWER : MovieDataLowercase = {
-    "title" : "Title",
-    "year" : "Year",
-    "rated" : "Rated",
-    "runtime" : "Runtime",
-    "genre" : "Genre",
-    "director" : "Director",
-    "writer" : "Writer",
-    "actors" : "Actors",
-    "plot" : "Plot",
-    "language" : "Language",
-    "country" : "Country",
-    "awards" : "Awards",
-    "poster" : "Poster",
-    "posterlocal": "PosterLocal",
-    "ratings" : "Ratings",
-	"released": "Released",
-    "metascore" : "Metascore",
-    "imdbrating" : "imdbRating",
-    "imdbvotes" : "imdbVotes",
-    "imdbid" : "imdbID",
-    "type" : "Type",
-    "dvd" : "DVD",
-    "boxoffice" : "BoxOffice",
-    "production" : "Production",
-    "website" : "Website",
-    "totalseasons" : "totalSeasons",
-    "response" : "Response",
-    "youtubeembed" : "YoutubeEmbed", 
+    title: "Title",
+    year: "Year",
+    rated: "Rated",
+    runtime: "Runtime",
+    genre: "Genre",
+    director: "Director",
+    writer: "Writer",
+    actors: "Actors",
+    plot: "Plot",
+    language: "Language",
+    country: "Country",
+    awards: "Awards",
+    poster: "Poster",
+    posterlocal: "PosterLocal",
+    ratings: "Ratings",
+    released: "Released",
+    metascore: "Metascore",
+    imdbrating: "imdbRating",
+    imdbvotes: "imdbVotes",
+    imdbid: "imdbID",
+    type: "Type",
+    dvd: "DVD",
+    boxoffice: "BoxOffice",
+    production: "Production",
+    website: "Website",
+    totalseasons: "totalSeasons",
+    response: "Response",
+    youtubeembed: "YoutubeEmbed",
+    tomatourl: "tomatoURL",
+    tomatometer: "tomatoMeter",
+    tomatoimage: "tomatoImage",
+    tomatorating: "tomatoRating",
+    tomatoreviews: "tomatoReviews",
+    tomatofresh: "tomatoFresh",
+    tomatorotten: "tomatoRotten",
+    tomatoconsensus: "tomatoConsensus",
+    tomatousermeter: "tomatoUserMeter",
+    tomatouserrating: "tomatoUserRating",
+    tomatouserreviews: "tomatoUserReviews"
 }
 
 export const TEST_SEARCH : MovieSearch = {

--- a/src/MoviegrabberSettings.ts
+++ b/src/MoviegrabberSettings.ts
@@ -14,6 +14,7 @@ export interface MoviegrabberSettings {
 	SeriesTemplatePath: string;
 
 	PlotLength: string;
+	RottenTomatoes: boolean;
 	FilenameTemplateMovie: string;
 	FilenameTemplateSeries: string;
 
@@ -34,6 +35,7 @@ export const DEFAULT_SETTINGS: MoviegrabberSettings = {
 	FilenameTemplateSeries: '{{Title}}',
 	enablePosterImageSave: false,
 	posterImagePath: '',
+	RottenTomatoes: true
 }
 
 export const DEFAULT_TEMPLATE: string = "---\n" +

--- a/src/interface/FolderSuggester.ts
+++ b/src/interface/FolderSuggester.ts
@@ -6,7 +6,7 @@ import { TextInputSuggest } from "./suggest";
 
 export class FolderSuggest extends TextInputSuggest<TFolder> {
     getSuggestions(inputStr: string): TFolder[] {
-        const abstractFiles = app.vault.getAllLoadedFiles();
+        const abstractFiles = this.app.vault.getAllLoadedFiles();
         const folders: TFolder[] = [];
         const lowerCaseInputStr = inputStr.toLowerCase();
 


### PR DESCRIPTION
Based on the settings, you can enable or disable querying OMDb for Rotten Tomatoes data. Defaults to enabled. RT data may not be very complete but at least the tomatoURL is very useful for accessing RT directly from entries. YMMV.

Part of this change incorporated a minor refactor to use a Type Mapping feature of TypeScript to keep the case insensitive mapping for template lookups in sync with the MovieData interface automatically.