### PR TITLE
feat: allow custom list separators to support YAML block lists

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -393,6 +393,7 @@ export default class Moviegrabber extends Plugin {
 			const suffix = split.length >= 3 ? split[2].replace(/\\\|/, '|') : '';
 			const transformation = split.length >= 4 ? split[3].replace(/\\\|/, '|') : '';
 			const stringFunction = split.length >= 5 ? split[4].replace(/\\\|/, '|') : '';
+			const separator = split.length >= 6 ? split[5].replace(/\\\|/g, '|').replace(/\\n/g, '\n') : ', ';
 
 			let result = '';
 			// handle the data being a list.
@@ -438,7 +439,7 @@ export default class Moviegrabber extends Plugin {
 				if (items[i] == '') {
 					continue;
 				}
-				result += result != '' ? ', ' : '';
+				result += result != '' ? separator : '';
 				result += prefix;
 				result += items[i]; // data
 				result += suffix;


### PR DESCRIPTION
This PR adds a 6th parameter to the template syntax, allowing users to define a custom separator for list items (Genres, Actors, Directors...).

## Problem
Currently, list fields are _hardcoded_ to join items with `,` (comma + space). This makes it impossible to generate valid `YAML` block-style lists for Obsidian Properties, which require newlines and specific indentation. As a result, list metadata often breaks or renders as a single string in Obsidian's Properties UI.

## Solution
I updated the `FillTemplate` function in `main.ts` to accept an optional 6th parameter for the separator.
 Users can now pass `\n` to insert real newlines, enabling proper YAML formatting.

**If the parameter is omitted, it defaults to the original `,` behavior.**

**Example Usage**
To create a valid YAML list of links in the frontmatter:

```yaml
genre: 
  - {{Genre|"[[|]]"|||\n  - }}
```

will output 

```yaml
genre:
  - "[[Action]]"
  - "[[Adventure]]"
  - "[[Sci-Fi]]"
```


> [!WARNING]
> _Obsidian will give an error in the template file because by default it will try to render the YAML properties. With real data, it works perfectly though. I'm not sure we can circumvent that unfortunately._

---

### Changes

- Modified `FillTemplate` to parse the 6th parameter.
- Added logic to replace literal `\n` characters with actual newlines.
- Updated the loop to use the dynamic separator instead of the hardcoded comma.